### PR TITLE
🔥 Remove CappedDataloader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,6 @@ export { deletePattern, unlinkPattern } from './lib/deletePattern'
 export { ExpiryModes, ClearMethods, SetOptions } from './lib/types'
 export { setJSON, getJSON, set } from './lib/utils'
 export { createRedisRepository } from './lib/redisRepository'
-export {
-  createDataLoaderFactory,
-  RedisDataLoader,
-  CappedDataLoader,
-} from './lib/dataloaders'
+export { createDataLoaderFactory, RedisDataLoader } from './lib/dataloaders'
 export { barrier } from './lib/barrier'
 export { cacheize } from './lib/cacheize'

--- a/src/lib/dataloaders.ts
+++ b/src/lib/dataloaders.ts
@@ -22,89 +22,12 @@ export interface RedisDataLoader<K, V> {
 }
 
 /**
- * DataLoader class with callback batch size watching. If callback limit is exceeded,
- * values are dispatched before the Node event loop finishes
- */
-export class CappedDataLoader<K, V, C = K> extends DataLoader<K, V, C> {
-  private readonly limit?: number
-  protected batchSize = 0
-  protected callbacks: Array<
-    Parameters<Required<DataLoader.Options<K, V, C>>['batchScheduleFn']>[0]
-  > = []
-
-  constructor(
-    batchLoadFn: DataLoader.BatchLoadFn<K, V>,
-    options?: DataLoader.Options<K, V, C> & {
-      capLimit?: number
-      batchScheduleFn?: never
-    }
-  ) {
-    super(batchLoadFn, {
-      ...options,
-      batchScheduleFn: callback => {
-        this.callbacks.push(callback)
-        setImmediate(() => this.dispatch())
-      },
-    })
-    this.batchSize = 0
-    this.callbacks = []
-    this.limit = options?.capLimit
-  }
-
-  protected dispatch = () => {
-    this.callbacks.forEach(callback => callback())
-    this.callbacks = []
-    this.batchSize = 0
-  }
-
-  loadMany(keys: ArrayLike<K>): Promise<Array<V | Error>> {
-    if (this.limit && this.batchSize + keys.length > this.limit) {
-      const remaining = this.limit - this.batchSize
-      const keysFirst = Array.prototype.slice.call(keys, 0, remaining)
-      const keysSecond = Array.prototype.slice.call(
-        keys,
-        remaining,
-        keys.length
-      )
-      const resFirst = super.loadMany(keysFirst)
-      this.dispatch()
-      const resSecond = this.loadMany(keysSecond)
-      return Promise.all([resFirst, resSecond]).then(([r1, r2]) => {
-        return [...r1, ...r2]
-      })
-    }
-    this.batchSize += keys.length
-    return super.loadMany(keys)
-  }
-
-  load(key: K): Promise<V> {
-    if (this.limit && this.batchSize + 1 > this.limit) {
-      const resFirst = super.load(key)
-      this.dispatch()
-      return resFirst
-    }
-    this.batchSize += 1
-    return super.load(key)
-  }
-}
-
-/**
  * Creates factory for Redis Dataloaders with simplified interface
  * @param redis
  * @param options Defines type of Dataloader class which will be used
  */
-export const createDataLoaderFactory = (
-  redis: Redis,
-  options:
-    | { type: DataLoaderType.Base }
-    | { type: DataLoaderType.Capped; capLimit: number } = {
-    type: DataLoaderType.Base,
-  }
-) => {
-  const { type, ...otherOptions } = options
+export const createDataLoaderFactory = (redis: Redis) => {
   const RedisDataLoader = redisDataLoaderFactory({ redis })
-  const DataLoaderClass =
-    type === DataLoaderType.Base ? DataLoader : CappedDataLoader
 
   return <T, K extends string & keyof T>(
     fetch: (keys: Readonly<Array<T[K]>>) => Promise<T[]>,
@@ -112,7 +35,7 @@ export const createDataLoaderFactory = (
   ): RedisDataLoader<T[K], T> => {
     const loader = new RedisDataLoader(
       options.keyPrefix,
-      new DataLoaderClass(
+      new DataLoader(
         async (ids: Readonly<Array<T[K]>>) => {
           const items = await fetch(ids)
           return ids.map(
@@ -120,7 +43,6 @@ export const createDataLoaderFactory = (
           )
         },
         {
-          ...otherOptions,
           cache: false,
         }
       ),


### PR DESCRIPTION
- Remove `CappedDataloder` in favor of the bult-in option `maxBatchSize` in `Dataloder` constructor

resolves #2 